### PR TITLE
Fixed ICC read

### DIFF
--- a/src/emv.c
+++ b/src/emv.c
@@ -758,6 +758,8 @@ mrb_s_check_emv_pki(mrb_state *mrb, mrb_value klass)
   static mrb_value
 mrb_s_emv__init(mrb_state *mrb, mrb_value klass)
 {
+  char attr[40] = {0};
+  OsIccInit(0, 0, attr);
   EMVInitTLVData();
   return mrb_true_value();
 }


### PR DESCRIPTION
Seems like the new EMV lib and dependencies(such as DEVICE) needed this OsIccInit in order to exchange APDU commands properly.