### PR TITLE
Fixed error printing large bmp file.

### DIFF
--- a/src/printer.c
+++ b/src/printer.c
@@ -655,7 +655,7 @@ mrb_pax_printer_s__print_big_bmp(mrb_state *mrb, mrb_value self)
   fread(buf, 1, size, fp);
   ret = print_1bitbmp_buf(buf, size);
 
-  if (buf) free(buf);
+  if (buf) mrb_free(mrb, buf);
   fclose(fp);
 
   return mrb_fixnum_value(ret);


### PR DESCRIPTION
We should release memory with mrb_free() instead of free(), as memory was allocated using mrb_malloc().