### PR TITLE
Prevent non exit application

### DIFF
--- a/mrblib/printer.rb
+++ b/mrblib/printer.rb
@@ -121,7 +121,9 @@ class PAX
     def self.thread_kill
       if self.thread
         self.printer_control.kill!
-        self.thread.join
+        if self.thread.alive?
+          self.thread.join
+        end
       end
     end
 


### PR DESCRIPTION
To avoid loop in a thread.join when a thread doesn't exist, we need to check if the thread is alive before the join. Otherwise the application will be stuck on it's exit.
It started after we started to cache those ruby applications.